### PR TITLE
Update src/library/TextInput

### DIFF
--- a/src/library/FauxControl/FauxControl.js
+++ b/src/library/FauxControl/FauxControl.js
@@ -59,6 +59,9 @@ const getIcons = ({
 };
 
 export default function FauxControl({
+  /* TargetX Custom Props */
+  borderRadius,
+
   afterItems,
   beforeItems,
   children,
@@ -128,7 +131,7 @@ export default function FauxControl({
     variant
   };
 
-  const underlayProps = { disabled, readOnly, variant };
+  const underlayProps = { borderRadius, disabled, readOnly, variant };
 
   return (
     <Root {...rootProps}>

--- a/src/library/FauxControl/styled.js
+++ b/src/library/FauxControl/styled.js
@@ -117,7 +117,7 @@ export const Suffix = styled('span', {
 export const Underlay = styled('div', {
   shouldForwardProp: (prop) =>
     ['disabled', 'readOnly'].indexOf(prop) === -1 && isPropValid(prop)
-})(({ disabled, readOnly, theme: baseTheme, variant }) => {
+})(({ borderRadius, disabled, readOnly, theme: baseTheme, variant }) => {
   const theme = fauxControlTheme(baseTheme);
 
   return {
@@ -129,7 +129,7 @@ export const Underlay = styled('div', {
       variant && !disabled && !readOnly
         ? theme[`borderColor_${variant}`]
         : theme.FauxControl_borderColor,
-    borderRadius: theme.FauxControl_borderRadius,
+    borderRadius: borderRadius ? borderRadius : theme.FauxControl_borderRadius,
     borderStyle: 'solid',
     borderWidth: theme.FauxControl_borderWidth,
     bottom: 0,

--- a/src/library/FauxControl/types.js
+++ b/src/library/FauxControl/types.js
@@ -8,6 +8,9 @@ import type {
 } from '../themes/types';
 
 export type FauxControlProps = {
+  /* TargetX Custom Props */
+  borderRadius?: number | string,
+
   afterItems?: React$Node,
   beforeItems?: React$Node,
   children?: React$Node,

--- a/src/library/TextInput/TextInput.js
+++ b/src/library/TextInput/TextInput.js
@@ -8,6 +8,9 @@ import type { TextInputDefaultProps, TextInputProps } from './types';
 
 const TextInput = (props: TextInputProps) => {
   const {
+    /* TargetX Custom props */
+    borderRadius,
+
     className,
     disabled,
     iconEnd,
@@ -34,6 +37,9 @@ const TextInput = (props: TextInputProps) => {
   };
 
   const rootProps = {
+    /* TargetX Custom props */
+    borderRadius,
+    
     className,
     control: Input,
     controlProps: inputProps,

--- a/src/library/TextInput/propTypes.js
+++ b/src/library/TextInput/propTypes.js
@@ -12,6 +12,9 @@ import {
 import { SIZE, TYPE, VARIANT } from './constants';
 
 export const textInputPropTypes = {
+  /* TargetX Custom props */
+  borderRadius: oneOfType([number, string]),
+
   className: string,
   defaultValue: string,
   disabled: bool,

--- a/src/library/TextInput/styled.js
+++ b/src/library/TextInput/styled.js
@@ -38,14 +38,9 @@ export const TextInputRoot = styled(ThemedFauxControl)(
       width: '100%',
 
       '& [role="img"]': {
-        color: theme.TextInputIcon_color,
         display: 'block',
         flex: '0 0 auto',
-        margin: `0 ${theme.TextInputIcon_marginHorizontal}`,
-
-        '&:last-of-type': {
-          color: theme.TextInputIcon_color
-        }
+        margin: `0 ${theme.TextInputIcon_marginHorizontal}`
       }
     };
   }

--- a/src/library/TextInput/types.js
+++ b/src/library/TextInput/types.js
@@ -12,6 +12,9 @@ type Type = $Keys<typeof TYPE>;
 type Variant = $Keys<typeof VARIANT>;
 
 export type TextInputProps = {
+  /* TargetX Custom props */
+  borderRadius?: number | string,
+
   className?: string,
   defaultValue?: string,
   disabled?: boolean,


### PR DESCRIPTION
Updates TextInput
   1. Support a `borderRadius` prop.
   2. Remove hardcoding of Icon colors, so the color can be set by the Icon Component itself.