### PR TITLE
Fix src/library/TextInput/styled

### DIFF
--- a/src/library/TextInput/styled.js
+++ b/src/library/TextInput/styled.js
@@ -38,6 +38,7 @@ export const TextInputRoot = styled(ThemedFauxControl)(
       width: '100%',
 
       '& [role="img"]': {
+        ...(variant ? { color: theme.TextInputIcon_color } : {}),
         display: 'block',
         flex: '0 0 auto',
         margin: `0 ${theme.TextInputIcon_marginHorizontal}`


### PR DESCRIPTION
When using a `variant` for TextInput the icon should have the appropriate color.